### PR TITLE
Fix PROJ link errors within SUMO.

### DIFF
--- a/CMake/FindPROJ.cmake
+++ b/CMake/FindPROJ.cmake
@@ -153,6 +153,7 @@ else ()
   message (STATUS "PROJ_INCLUDE_DIR=${PROJ_INCLUDE_DIR}")
   message (STATUS "PROJ_API_FILE=${PROJ_API_FILE}")
   message (STATUS "PROJ_LIBRARY=${PROJ_LIBRARY}")
-  add_compile_definitions (PROJ_DLL=)
 
 endif ()
+
+add_compile_definitions (PROJ_DLL=)

--- a/CMake/FindSUMO.cmake
+++ b/CMake/FindSUMO.cmake
@@ -130,3 +130,5 @@ else ()
   message (STATUS "Found ${DEPENDENCY_NAME}. Skipping build...")
 
 endif ()
+
+add_compile_definitions (PROJ_DLL=)


### PR DESCRIPTION
Fix PROJ linker errors within SUMO due to incorrect dllexport/dllimport spec.