### PR TITLE
Add editor camera to compare to Google Street View renders

### DIFF
--- a/Source/CarlaDigitalTwinsTool/Private/Utils/GoogleStreetViewFetcher.cpp
+++ b/Source/CarlaDigitalTwinsTool/Private/Utils/GoogleStreetViewFetcher.cpp
@@ -38,7 +38,7 @@ void UGoogleStreetViewFetcher::RequestGoogleStreetViewImage()
     FVector2D latlon = UMapGenFunctionLibrary::InverseTransverseMercatorProjection( CameraLocation.X, CameraLocation.Y, OriginLat, OriginLon );
     double lat = latlon.X;
     double lon = latlon.Y;
-    int heading = static_cast<int>(FMath::Fmod(CameraRotation.Yaw + 360.0f, 360.0f));
+    int heading = static_cast<int>(FMath::Fmod(CameraRotation.Yaw +90.0f + 360.0f, 360.0f));    // Offset of 90º
 
     FString URL = FString::Printf(
         TEXT("https://maps.googleapis.com/maps/api/streetview?size=640x480&location=%.6f,%.6f&heading=%d&pitch=0&key=%s"),

--- a/Source/CarlaDigitalTwinsTool/Public/Utils/GoogleStreetViewManager.h
+++ b/Source/CarlaDigitalTwinsTool/Public/Utils/GoogleStreetViewManager.h
@@ -19,7 +19,10 @@ public:
     void Initialize(UWorld* World, FTransform CameraTransform, FVector2D InOriginGeoCoordinates, const FString& InGoogleAPIKey);
 
     UPROPERTY(EditAnywhere, Category = "GoogleStreetView")
-    ACameraActor* CameraActor;
+    ACameraActor* GoogleCamera;
+
+    UPROPERTY(EditAnywhere, Category = "GoogleStreetView")
+    ACameraActor* EditorCamera;
 
     UPROPERTY(EditAnywhere, Category = "GoogleStreetView")
     FVector2D OriginGeoCoordinates;


### PR DESCRIPTION
Add editor camera to better compare to Google Street View renders

- [x] Add editor camera
- [x] Synchronize both cameras when the editor camera is moved
- [x] Fix 90º mismatch in Google Street View heading images

[Screencast from 11-06-25 19:37:34.webm](https://github.com/user-attachments/assets/526ef6f3-8348-493d-a656-904030ba03d7)

