### PR TITLE
Avoid holes under the roads

### DIFF
--- a/Source/CarlaDigitalTwinsTool/Private/Generation/OpenDriveToMap.cpp
+++ b/Source/CarlaDigitalTwinsTool/Private/Generation/OpenDriveToMap.cpp
@@ -1169,16 +1169,16 @@ float UOpenDriveToMap::GetHeightForLandscape( FVector Origin ){
   CollisionQuery.AddIgnoredActors(Landscapes);
   FCollisionResponseParams CollisionParams;
 
-  if( GetEditorWorld()->LineTraceSingleByChannel(
-    HitResult,
-    Start,
-    End,
-    ECollisionChannel::ECC_WorldStatic,
-    CollisionQuery,
-    CollisionParams) )
-  {
-    return (HitResult.Location.Z) -1.0f;
-  }
+  // if( GetEditorWorld()->LineTraceSingleByChannel(
+  //   HitResult,
+  //   Start,
+  //   End,
+  //   ECollisionChannel::ECC_WorldStatic,
+  //   CollisionQuery,
+  //   CollisionParams) )
+  // {
+  //   return (HitResult.Location.Z) -1.0f;
+  // }
   
   // If no hit, return the height based on the origin coordinates
   return GetHeight(Origin.X, Origin.Y, false) - 2.0f;

--- a/Source/CarlaDigitalTwinsTool/Private/Generation/OpenDriveToMap.cpp
+++ b/Source/CarlaDigitalTwinsTool/Private/Generation/OpenDriveToMap.cpp
@@ -792,7 +792,9 @@ void UOpenDriveToMap::GenerateRoadMesh( const boost::optional<carla::road::Map>&
       {
         for (auto& Vertex : Vertices)
         {
-          Vertex.z = (GetHeight(Vertex.x * 100.0f, Vertex.y * 100.0f, false) + 15.0f) / 100.0f;
+          if (Vertex.z>0){  // Apply only to top vertices, to leave sidewalk wall
+            Vertex.z = (GetHeight(Vertex.x * 100.0f, Vertex.y * 100.0f, false) + 15.0f) / 100.0f;
+          }
         }
       }
 

--- a/Source/CarlaDigitalTwinsTool/Private/Generation/OpenDriveToMap.cpp
+++ b/Source/CarlaDigitalTwinsTool/Private/Generation/OpenDriveToMap.cpp
@@ -1175,7 +1175,7 @@ float UOpenDriveToMap::GetHeightForLandscape( FVector Origin ){
     CollisionQuery,
     CollisionParams) )
   {
-    return (HitResult.Location.Z) - 100.0f;
+    return (HitResult.Location.Z) -1.0f;
   }
   
   // If no hit, return the height based on the origin coordinates

--- a/Source/CarlaDigitalTwinsTool/Private/Generation/OpenDriveToMap.cpp
+++ b/Source/CarlaDigitalTwinsTool/Private/Generation/OpenDriveToMap.cpp
@@ -781,7 +781,7 @@ void UOpenDriveToMap::GenerateRoadMesh( const boost::optional<carla::road::Map>&
         for (auto& Vertex : Vertices)
         {
           FVector FV = Vertex.ToFVector();
-          Vertex.z = GetHeight(Vertex.x * 100.0f, Vertex.y * 100.0f, DistanceToLaneBorder(ParamCarlaMap, FV) > 65.0f) / 100.0f;
+          Vertex.z += GetHeight(Vertex.x * 100.0f, Vertex.y * 100.0f, DistanceToLaneBorder(ParamCarlaMap, FV) > 65.0f) / 100.0f;
         }
 #if ENGINE_MAJOR_VERSION < 5
         carla::geom::Simplification Simplify(0.15);
@@ -792,9 +792,7 @@ void UOpenDriveToMap::GenerateRoadMesh( const boost::optional<carla::road::Map>&
       {
         for (auto& Vertex : Vertices)
         {
-          if (Vertex.z>0){  // Apply only to top vertices, to leave sidewalk wall
-            Vertex.z = (GetHeight(Vertex.x * 100.0f, Vertex.y * 100.0f, false) + 15.0f) / 100.0f;
-          }
+          Vertex.z += (GetHeight(Vertex.x * 100.0f, Vertex.y * 100.0f, false) + 15.0f) / 100.0f;
         }
       }
 
@@ -935,7 +933,7 @@ void UOpenDriveToMap::GenerateLaneMarks(const boost::optional<carla::road::Map>&
     for (auto& Vertex : Mesh->GetVertices())
     {
       FVector VertexFVector = Vertex.ToFVector();
-      Vertex.z = GetHeight(Vertex.x * 100.0f, Vertex.y * 100.0f, DistanceToLaneBorder(ParamCarlaMap,VertexFVector) > 65.0f ) / 100.0f + 0.01f;
+      Vertex.z += GetHeight(Vertex.x * 100.0f, Vertex.y * 100.0f, DistanceToLaneBorder(ParamCarlaMap,VertexFVector) > 65.0f ) / 100.0f + 0.01f;
       MeshCentroid += Vertex.ToFVector();
     }
 

--- a/Source/CarlaDigitalTwinsTool/Private/Generation/OpenDriveToMap.cpp
+++ b/Source/CarlaDigitalTwinsTool/Private/Generation/OpenDriveToMap.cpp
@@ -792,7 +792,7 @@ void UOpenDriveToMap::GenerateRoadMesh( const boost::optional<carla::road::Map>&
       {
         for (auto& Vertex : Vertices)
         {
-          Vertex.z = (GetHeight(Vertex.x * 100.0f, Vertex.y * 100.0f, false) + 0.15f) / 100.0f;
+          Vertex.z = (GetHeight(Vertex.x * 100.0f, Vertex.y * 100.0f, false) + 15.0f) / 100.0f;
         }
       }
 

--- a/Source/CarlaDigitalTwinsTool/Private/Generation/OpenDriveToMap.cpp
+++ b/Source/CarlaDigitalTwinsTool/Private/Generation/OpenDriveToMap.cpp
@@ -781,7 +781,7 @@ void UOpenDriveToMap::GenerateRoadMesh( const boost::optional<carla::road::Map>&
         for (auto& Vertex : Vertices)
         {
           FVector FV = Vertex.ToFVector();
-          Vertex.z += GetHeight(Vertex.x * 100.0f, Vertex.y * 100.0f, DistanceToLaneBorder(ParamCarlaMap, FV) > 65.0f) / 100.0f;
+          Vertex.z = GetHeight(Vertex.x * 100.0f, Vertex.y * 100.0f, DistanceToLaneBorder(ParamCarlaMap, FV) > 65.0f) / 100.0f;
         }
 #if ENGINE_MAJOR_VERSION < 5
         carla::geom::Simplification Simplify(0.15);
@@ -792,7 +792,7 @@ void UOpenDriveToMap::GenerateRoadMesh( const boost::optional<carla::road::Map>&
       {
         for (auto& Vertex : Vertices)
         {
-          Vertex.z += (GetHeight(Vertex.x * 100.0f, Vertex.y * 100.0f, false) + 0.15f) / 100.0f;
+          Vertex.z = (GetHeight(Vertex.x * 100.0f, Vertex.y * 100.0f, false) + 0.15f) / 100.0f;
         }
       }
 
@@ -933,7 +933,7 @@ void UOpenDriveToMap::GenerateLaneMarks(const boost::optional<carla::road::Map>&
     for (auto& Vertex : Mesh->GetVertices())
     {
       FVector VertexFVector = Vertex.ToFVector();
-      Vertex.z += GetHeight(Vertex.x * 100.0f, Vertex.y * 100.0f, DistanceToLaneBorder(ParamCarlaMap,VertexFVector) > 65.0f ) / 100.0f + 0.01f;
+      Vertex.z = GetHeight(Vertex.x * 100.0f, Vertex.y * 100.0f, DistanceToLaneBorder(ParamCarlaMap,VertexFVector) > 65.0f ) / 100.0f + 0.01f;
       MeshCentroid += Vertex.ToFVector();
     }
 


### PR DESCRIPTION
With the last heightmap changes, the terrain was created just below the assets such as sidewalks and roads. This led to holes below the raods and artifacts in the terrain. This PR changes this, and properly projects the road, sidewalks and lane markers to the floor.