### PR TITLE
Remove automatic call to vcvars

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
      ```bash
      ./Setup.sh
      ```
-   - **On Windows (in a native tools command prompt):**
+   - **On Windows (on an X64 Native Tools Command Prompt for VS 2022):**
      ```cmd
      Setup.bat
      ```

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
      ```bash
      ./Setup.sh
      ```
-   - **On Windows (in a developer terminal):**
+   - **On Windows (in a native tools command prompt):**
      ```cmd
      Setup.bat
      ```

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
      ```bash
      ./Setup.sh
      ```
-   - **On Windows (double-click or terminal):**
+   - **On Windows (in a developer terminal):**
      ```cmd
      Setup.bat
      ```

--- a/Setup.bat
+++ b/Setup.bat
@@ -3,8 +3,6 @@
 set SCRIPT_PATH=%~f0
 set SOURCE_PATH=%SCRIPT_PATH:Setup.bat=%
 
-call "%PROGRAMFILES%/Microsoft Visual Studio/2022/Community/VC/Auxiliary/Build/vcvars64.bat"
-
 set BOOST_COMPONENTS="asio;iterator;date_time;geometry;container;variant2;gil;filesystem"
 
 cmake ^


### PR DESCRIPTION
This PR removes the call to vcvars from the Setup.bat script. This means that from now on the user must run this terminal on a windows developer terminal.