### PR TITLE
Generate road render for curbs in tiles

### DIFF
--- a/Source/CarlaDigitalTwinsTool/Private/Generation/OpenDriveToMap.cpp
+++ b/Source/CarlaDigitalTwinsTool/Private/Generation/OpenDriveToMap.cpp
@@ -782,7 +782,6 @@ void UOpenDriveToMap::LoadMap()
 			FString CurrentMapName = World->GetMapName();
 			CurrentMapName.RemoveFromStart(World->StreamingLevelsPrefix);
 			UGameplayStatics::OpenLevel(World, FName(*CurrentMapName));
-			RenderRoadToTexture(World);
 		}
 
 		for (UDGTImplementable* Tool : ToolInstances)
@@ -847,6 +846,9 @@ void UOpenDriveToMap::GenerateAll(const boost::optional<carla::road::Map>& Param
 
 	UE_LOG(LogCarlaDigitalTwinsTool, Log, TEXT("UOpenDriveToMap::GenerateAll() Generating Misc stuff..... "));
 	GenerationFinished(MinLocation, MaxLocation);
+
+	UE_LOG(LogCarlaDigitalTwinsTool, Log, TEXT("UOpenDriveToMap::GenerateAll() Generating road render..... "));
+	RenderRoadToTexture(MinLocation, MaxLocation);
 
 #if PLATFORM_LINUX
 	if (bUseMitsuba)
@@ -1591,9 +1593,15 @@ void UOpenDriveToMap::UnloadWorldPartitionRegion(const FBox& RegionBox)
 	}
 }
 
-void UOpenDriveToMap::RenderRoadToTexture(UWorld* World)
+void UOpenDriveToMap::RenderRoadToTexture(FVector MinLocation, FVector MaxLocation)
 {
+	UE_LOG(LogCarlaDigitalTwinsTool, Log, TEXT("Render road for curb generation"));
+
+	UWorld* World = GetEditorWorld();
+
 	FBox Bounds(EForceInit::ForceInitToZero);
+	Bounds += MinLocation;
+	Bounds += MaxLocation;
 
 	FString RoadLabel = "DrivingLane";
 #if PLATFORM_LINUX
@@ -1610,8 +1618,6 @@ void UOpenDriveToMap::RenderRoadToTexture(UWorld* World)
 		HiddenActors.Reserve(Actors.Num());
 		for (auto& Actor : Actors)
 		{
-			auto BoundingBox = Actor->GetComponentsBoundingBox();
-			Bounds += BoundingBox;
 			auto Name = Actor->GetActorLabel();
 
 			if (!Name.Contains(RoadLabel, ESearchCase::CaseSensitive))

--- a/Source/CarlaDigitalTwinsTool/Private/Generation/OpenDriveToMap.cpp
+++ b/Source/CarlaDigitalTwinsTool/Private/Generation/OpenDriveToMap.cpp
@@ -784,6 +784,8 @@ void UOpenDriveToMap::LoadMap()
 			UGameplayStatics::OpenLevel(World, FName(*CurrentMapName));
 		}
 
+		GenerateCurbSplines();
+
 		for (UDGTImplementable* Tool : ToolInstances)
 		{
 			if (Tool)
@@ -1595,7 +1597,7 @@ void UOpenDriveToMap::UnloadWorldPartitionRegion(const FBox& RegionBox)
 
 void UOpenDriveToMap::RenderRoadToTexture(FVector MinLocation, FVector MaxLocation)
 {
-	UE_LOG(LogCarlaDigitalTwinsTool, Log, TEXT("Render road for curb generation"));
+	UE_LOG(LogCarlaDigitalTwinsTool, Log, TEXT("Render road for curbs generation"));
 
 	UWorld* World = GetEditorWorld();
 
@@ -1632,10 +1634,11 @@ void UOpenDriveToMap::RenderRoadToTexture(FVector MinLocation, FVector MaxLocati
 
 	auto Center = Bounds.GetCenter();
 	auto Extent = FVector2D(Bounds.Max) - FVector2D(Bounds.Min);
-
 	auto RenderTargetScale = UE_CM_TO_M * 8;
 	auto RenderTargetExtent = Extent * RenderTargetScale;
 	auto RenderTargetSize = FIntPoint((int32) std::round(RenderTargetExtent.X), (int32) std::round(RenderTargetExtent.Y));
+
+	UE_LOG(LogCarlaDigitalTwinsTool, Log, TEXT("RenderTargetSize: %i, %i"), RenderTargetSize.X, RenderTargetSize.Y);
 
 	auto RenderTarget = NewObject<UTextureRenderTarget2D>();
 	RenderTarget->AddToRoot();
@@ -1679,7 +1682,7 @@ void UOpenDriveToMap::RenderRoadToTexture(FVector MinLocation, FVector MaxLocati
 	ImageTask->PixelData = MoveTemp(PixelData);
 
 	FString OutPath = UGenerationPathsHelper::GetPythonIntermediatePath(MapName);
-	FString ImagePath = OutPath / TEXT("road_render.png");
+	FString ImagePath = OutPath / TEXT("road_render") + GetStringForCurrentTile() + TEXT(".png");
 
 	ImageTask->Filename = ImagePath;
 	ImageTask->Format = EImageFormat::PNG;
@@ -1696,10 +1699,34 @@ void UOpenDriveToMap::RenderRoadToTexture(FVector MinLocation, FVector MaxLocati
 	// Camera->Destroy();
 
 	Task.Wait();
+}
 
-	RunPythonRoadEdges(FVector2D(Center.X, Center.Y), FVector2D(Extent.X, Extent.Y));
+void UOpenDriveToMap::GenerateCurbSplines()
+{
+	UE_LOG(LogCarlaDigitalTwinsTool, Log, TEXT("Create splines for curbs generation"));
+
+	UWorld* World = GetEditorWorld();
+
+	FString OutPath = UGenerationPathsHelper::GetPythonIntermediatePath(MapName);
+
+	RunPythonMergeTiles();
+
+	RunPythonRoadEdges();
 
 	auto JsonPath = OutPath / TEXT("contours.json");
+
+	MinPosition = FVector(0.0f, 0.0f, 0.0f);
+	MaxPosition = FVector(NumTilesInXY.X * TileSize, NumTilesInXY.Y * -TileSize, 0.0f);
+
+	FBox Bounds(EForceInit::ForceInitToZero);
+	Bounds += MinPosition;
+	Bounds += MaxPosition;
+
+	auto Center = Bounds.GetCenter();
+	auto Extent = FVector2D(Bounds.Max) - FVector2D(Bounds.Min);
+	auto RenderTargetScale = UE_CM_TO_M * 8;
+	auto RenderTargetExtent = Extent * RenderTargetScale;
+	auto RenderTargetSize = FIntPoint((int32) std::round(RenderTargetExtent.X), (int32) std::round(RenderTargetExtent.Y));
 
 	auto RoadSplines =
 		UGeometryImporter::CreateSplinesFromJson(World, JsonPath, FVector2D(Center.X, Center.Y), Extent, RenderTargetSize);
@@ -1766,7 +1793,22 @@ void UOpenDriveToMap::RunPythonScript(FString ScriptPath, FString Args)
 	UE_LOG(LogCarlaDigitalTwinsTool, Display, TEXT("Python Output:\n%s"), *Output);
 }
 
-void UOpenDriveToMap::RunPythonRoadEdges(FVector2D Center, FVector2D Extent)
+void UOpenDriveToMap::RunPythonMergeTiles()
+{
+	UE_LOG(LogCarlaDigitalTwinsTool, Log, TEXT("Running Python merge rendered tiles script..."));
+
+	FString PluginPath = UGenerationPathsHelper::GetDigitalTwinsPluginPath();
+	FString ScriptPath = PluginPath / TEXT("Content/Python/merge_images.py");
+	FString OutPath = UGenerationPathsHelper::GetPythonIntermediatePath(MapName);
+
+	FString Args;
+	Args += FString::Printf(TEXT("\"%s\" "), *ScriptPath);
+	Args += FString::Printf(TEXT("--folder_path=\"%s\" "), *OutPath);
+
+	RunPythonScript(ScriptPath, Args);
+}
+
+void UOpenDriveToMap::RunPythonRoadEdges()
 {
 	UE_LOG(LogCarlaDigitalTwinsTool, Log, TEXT("Running Python road edges extraction script..."));
 

--- a/Source/CarlaDigitalTwinsTool/Private/Generation/OpenDriveToMap.cpp
+++ b/Source/CarlaDigitalTwinsTool/Private/Generation/OpenDriveToMap.cpp
@@ -1648,7 +1648,7 @@ void UOpenDriveToMap::RenderRoadToTexture(FVector MinLocation, FVector MaxLocati
 
 	FActorSpawnParameters ActorSpawnParameters;
 	ActorSpawnParameters.SpawnCollisionHandlingOverride = ESpawnActorCollisionHandlingMethod::AlwaysSpawn;
-	ActorSpawnParameters.Name = TEXT("camera");
+	ActorSpawnParameters.Name = FName(*(TEXT("Camera") + GetStringForCurrentTile()));
 
 	auto Camera = World->SpawnActor<ASceneCapture2D>(ASceneCapture2D::StaticClass(), ActorSpawnParameters);
 

--- a/Source/CarlaDigitalTwinsTool/Public/Generation/OpenDriveToMap.h
+++ b/Source/CarlaDigitalTwinsTool/Public/Generation/OpenDriveToMap.h
@@ -243,7 +243,13 @@ protected:
   void RunPythonScript(FString ScriptPath, FString Args);
 
   UFUNCTION(BlueprintCallable, Category = "Assets Placement")
-  void RunPythonRoadEdges(FVector2D Center, FVector2D Extent);
+  void RunPythonMergeTiles();
+
+  UFUNCTION(BlueprintCallable, Category = "Assets Placement")
+  void RunPythonRoadEdges();
+
+  UFUNCTION(BlueprintCallable, Category = "Assets Placement")
+  void GenerateCurbSplines();
 
   UFUNCTION(BlueprintCallable, Category = "Mitsuba")
   void ExportStaticMeshToOBJ(UStaticMesh *StaticMesh, const FString &OutputPath);

--- a/Source/CarlaDigitalTwinsTool/Public/Generation/OpenDriveToMap.h
+++ b/Source/CarlaDigitalTwinsTool/Public/Generation/OpenDriveToMap.h
@@ -237,7 +237,7 @@ public:
 protected:
 
   UFUNCTION(BlueprintCallable, Category = "Assets Placement")
-  void RenderRoadToTexture(UWorld* World);
+  void RenderRoadToTexture(FVector MinLocation, FVector MaxLocation);
 
   UFUNCTION(BlueprintCallable, Category = "Assets Placement")
   void RunPythonScript(FString ScriptPath, FString Args);


### PR DESCRIPTION
As stated in #104, curb spawner crashes when generating road render in too large maps. The road renderer is run at each tile in this PR to avoid too large textures.

[Related content PR](https://bitbucket.org/carla-simulator/digitaltwins/pull-requests/19).