### PR TITLE
Fixes in road renders

### DIFF
--- a/Source/CarlaDigitalTwinsTool/Private/Generation/OpenDriveToMap.cpp
+++ b/Source/CarlaDigitalTwinsTool/Private/Generation/OpenDriveToMap.cpp
@@ -1663,6 +1663,17 @@ void UOpenDriveToMap::RenderRoadToTexture(FVector MinLocation, FVector MaxLocati
 	CaptureComponent->bCaptureOnMovement = false;
 	CaptureComponent->TextureTarget = RenderTarget;
 
+	CaptureComponent->ShowFlags.SetLumenGlobalIllumination(false);
+	CaptureComponent->ShowFlags.SetLumenReflections(false);
+	CaptureComponent->ShowFlags.SetGlobalIllumination(false);
+	CaptureComponent->ShowFlags.SetScreenSpaceReflections(false);
+	CaptureComponent->ShowFlags.SetDistanceFieldAO(false);
+	CaptureComponent->ShowFlags.SetTemporalAA(false);
+	CaptureComponent->ShowFlags.SetMotionBlur(false);
+	CaptureComponent->ShowFlags.SetBloom(false);
+	CaptureComponent->ShowFlags.SetVolumetricFog(false);
+	CaptureComponent->ShowFlags.SetDynamicShadows(false);
+
 	auto CameraZ = std::max(Bounds.Max.X, std::max(Bounds.Max.Y, Bounds.Max.Z));
 	auto Location = FVector(Center.X, Center.Y, CameraZ);
 
@@ -1696,7 +1707,8 @@ void UOpenDriveToMap::RenderRoadToTexture(FVector MinLocation, FVector MaxLocati
 	for (auto& HiddenActor : HiddenActors)
 		HiddenActor->SetActorHiddenInGame(false);
 
-	// Camera->Destroy();
+	RenderTarget->RemoveFromRoot();
+	Camera->Destroy();
 
 	Task.Wait();
 }

--- a/Source/CarlaDigitalTwinsTool/Private/Generation/OpenDriveToMap.cpp
+++ b/Source/CarlaDigitalTwinsTool/Private/Generation/OpenDriveToMap.cpp
@@ -784,7 +784,7 @@ void UOpenDriveToMap::LoadMap()
 			UGameplayStatics::OpenLevel(World, FName(*CurrentMapName));
 		}
 
-		GenerateCurbSplines();
+		GenerateCurbSplinesFromRoadRenders();
 
 		for (UDGTImplementable* Tool : ToolInstances)
 		{
@@ -799,6 +799,25 @@ void UOpenDriveToMap::LoadMap()
 #endif
 		Landscapes.Empty();
 	}
+}
+
+void UOpenDriveToMap::GenerateCurbSplinesFromRoadRenders()
+{
+	UE_LOG(LogCarlaDigitalTwinsTool, Log, TEXT("Generating road renders and splines for curbs"));
+
+	CurrentTilesInXY.X = 0;
+	CurrentTilesInXY.Y = 0;
+	
+	do
+	{
+		MinPosition = FVector(CurrentTilesInXY.X * TileSize, CurrentTilesInXY.Y * -TileSize, 0.0f);
+		MaxPosition = FVector((CurrentTilesInXY.X + 1.0f) * TileSize, (CurrentTilesInXY.Y + 1.0f) * -TileSize, 0.0f);
+		
+		RenderRoadToTexture(MinPosition, MaxPosition);
+
+	} while (GoNextTile());
+
+	GenerateCurbSplines();
 }
 
 TArray<AActor*> UOpenDriveToMap::GenerateMiscActors(float Offset, FVector MinLocation, FVector MaxLocation)
@@ -848,9 +867,6 @@ void UOpenDriveToMap::GenerateAll(const boost::optional<carla::road::Map>& Param
 
 	UE_LOG(LogCarlaDigitalTwinsTool, Log, TEXT("UOpenDriveToMap::GenerateAll() Generating Misc stuff..... "));
 	GenerationFinished(MinLocation, MaxLocation);
-
-	UE_LOG(LogCarlaDigitalTwinsTool, Log, TEXT("UOpenDriveToMap::GenerateAll() Generating road render..... "));
-	RenderRoadToTexture(MinLocation, MaxLocation);
 
 #if PLATFORM_LINUX
 	if (bUseMitsuba)

--- a/Source/CarlaDigitalTwinsTool/Public/Generation/OpenDriveToMap.h
+++ b/Source/CarlaDigitalTwinsTool/Public/Generation/OpenDriveToMap.h
@@ -251,6 +251,9 @@ protected:
   UFUNCTION(BlueprintCallable, Category = "Assets Placement")
   void GenerateCurbSplines();
 
+  UFUNCTION(BlueprintCallable, Category = "Assets Placement")
+  void GenerateCurbSplinesFromRoadRenders();
+
   UFUNCTION(BlueprintCallable, Category = "Mitsuba")
   void ExportStaticMeshToOBJ(UStaticMesh *StaticMesh, const FString &OutputPath);
 


### PR DESCRIPTION
- Fix crash in scene capture disabling proper flags.
- Fix issue with missing roads in curbs creation, due to some roads not created yet as was going sequentally over tiles (first image). Solved by moving the road renders to a posterior loop over tiles (second image).

<img width="794" height="781" alt="Screenshot_from_2025-08-29_13-24-15" src="https://github.com/user-attachments/assets/55ee764e-43e4-4fdf-a6e8-4f6fd268f0a8" />


<img width="849" height="848" alt="Screenshot from 2025-08-29 13-21-26" src="https://github.com/user-attachments/assets/98872783-6b0f-4bbe-98e1-54c010a19750" />
