### PR TITLE
Fix curbs to spawn in correct heights

### DIFF
--- a/Source/CarlaDigitalTwinsTool/Private/Generation/OpenDriveToMap.cpp
+++ b/Source/CarlaDigitalTwinsTool/Private/Generation/OpenDriveToMap.cpp
@@ -1780,7 +1780,7 @@ void UOpenDriveToMap::GenerateCurbSplines(FString MeshLayer)
 		int32 NumPoints = Spline->GetNumberOfSplinePoints();
 		for (int32 i = 0; i < NumPoints; ++i)
 		{
-			// Firstly project level 0 spline points to the floor and level 1 to a higher height
+			// Firstly project level 0 spline points to the floor and level 1 to a higher height (maybe this is not required and can be cleaned up)
 			FVector Pos = Spline->GetLocationAtSplinePoint(i, ESplineCoordinateSpace::Local);
 
 			Pos.Z = GetHeight(Pos.X, Pos.Y, false);
@@ -1794,7 +1794,7 @@ void UOpenDriveToMap::GenerateCurbSplines(FString MeshLayer)
 			Spline->UpdateSpline();
 
 			// Improve spline placement with ray cast
-			UOpenDriveToMap::AlignSplineToRoadMesh(Spline, World);
+			UOpenDriveToMap::AlignSplineToRoadMesh(Spline, World, MeshLayer);
 
 			UE_LOG(LogCarlaDigitalTwinsTool, Log, TEXT("Spline updated"));
 		}
@@ -1803,7 +1803,7 @@ void UOpenDriveToMap::GenerateCurbSplines(FString MeshLayer)
 	GeneratedSplines.Append(RoadSplines);
 }
 
-void UOpenDriveToMap::AlignSplineToRoadMesh(USplineComponent* Spline, UWorld* World)
+void UOpenDriveToMap::AlignSplineToRoadMesh(USplineComponent* Spline, UWorld* World, const FString& NamePrefix)
 {
     if (!Spline || !World) return;
 
@@ -1821,10 +1821,18 @@ void UOpenDriveToMap::AlignSplineToRoadMesh(USplineComponent* Spline, UWorld* Wo
         FHitResult Hit;
         if (World->LineTraceSingleByChannel(Hit, Start, End, ECC_Visibility, QueryParams))
         {
-            FVector NewLocation = PointLocation;
-            NewLocation.Z = Hit.Location.Z;
+            UPrimitiveComponent* HitComp = Hit.GetComponent();
+            if (HitComp)
+            {
+                FString CompName = HitComp->GetName();
+                if (CompName.StartsWith(NamePrefix))
+                {
+                    FVector NewLocation = PointLocation;
+                    NewLocation.Z = Hit.Location.Z;
 
-            Spline->SetLocationAtSplinePoint(i, NewLocation, ESplineCoordinateSpace::World, true);
+                    Spline->SetLocationAtSplinePoint(i, NewLocation, ESplineCoordinateSpace::World, true);
+                }
+            }
         }
     }
 

--- a/Source/CarlaDigitalTwinsTool/Private/Generation/OpenDriveToMap.cpp
+++ b/Source/CarlaDigitalTwinsTool/Private/Generation/OpenDriveToMap.cpp
@@ -1774,25 +1774,61 @@ void UOpenDriveToMap::GenerateCurbSplines(FString MeshLayer)
 
 	UE_LOG(LogCarlaDigitalTwinsTool, Log, TEXT("Number of road splines: %i"), RoadSplines.Num());
 
-	// Project spline points to the floor
+	
 	for (auto Spline : RoadSplines)
 	{
 		int32 NumPoints = Spline->GetNumberOfSplinePoints();
 		for (int32 i = 0; i < NumPoints; ++i)
 		{
+			// Firstly project level 0 spline points to the floor and level 1 to a higher height
 			FVector Pos = Spline->GetLocationAtSplinePoint(i, ESplineCoordinateSpace::Local);
 
 			Pos.Z = GetHeight(Pos.X, Pos.Y, false);
 
+			if (MeshLayer=="Layer1"){
+				Pos.Z += OpenDriveGenParams.DefaultOSMLayerHeight;
+			}
+
 			Spline->SetLocationAtSplinePoint(i, Pos, ESplineCoordinateSpace::Local, false);
 
 			Spline->UpdateSpline();
+
+			// Improve spline placement with ray cast
+			UOpenDriveToMap::AlignSplineToRoadMesh(Spline, World);
 
 			UE_LOG(LogCarlaDigitalTwinsTool, Log, TEXT("Spline updated"));
 		}
 	}
 
 	GeneratedSplines.Append(RoadSplines);
+}
+
+void UOpenDriveToMap::AlignSplineToRoadMesh(USplineComponent* Spline, UWorld* World)
+{
+    if (!Spline || !World) return;
+
+    FCollisionQueryParams QueryParams;
+    QueryParams.bTraceComplex = true;
+    QueryParams.AddIgnoredActor(Spline->GetOwner());
+
+    for (int32 i = 0; i < Spline->GetNumberOfSplinePoints(); i++)
+    {
+        FVector PointLocation = Spline->GetLocationAtSplinePoint(i, ESplineCoordinateSpace::World);
+
+        FVector Start = FVector(PointLocation.X, PointLocation.Y, PointLocation.Z + 10000.0f);
+        FVector End   = FVector(PointLocation.X, PointLocation.Y, PointLocation.Z - 10000.0f);
+
+        FHitResult Hit;
+        if (World->LineTraceSingleByChannel(Hit, Start, End, ECC_Visibility, QueryParams))
+        {
+            FVector NewLocation = PointLocation;
+            NewLocation.Z = Hit.Location.Z;
+
+            Spline->SetLocationAtSplinePoint(i, NewLocation, ESplineCoordinateSpace::World, true);
+        }
+    }
+
+    Spline->UpdateSpline();
 }
 
 void UOpenDriveToMap::RunPythonScript(FString ScriptPath, FString Args)

--- a/Source/CarlaDigitalTwinsTool/Private/Generation/OpenDriveToMap.cpp
+++ b/Source/CarlaDigitalTwinsTool/Private/Generation/OpenDriveToMap.cpp
@@ -522,6 +522,8 @@ void UOpenDriveToMap::GenerateTile()
 	FFileHelper::LoadFileToString(FileContent, *FilePath);
 	std::string opendrive_xml = carla::rpc::FromLongFString(FileContent);
 	UE_LOG(LogCarlaDigitalTwinsTool, Warning, TEXT("UOpenDriveToMap::GenerateTile() Loading File..... "));
+	UE_LOG(LogCarlaDigitalTwinsTool, Warning, TEXT("Current tile: %i, %i"),CurrentTilesInXY.X, CurrentTilesInXY.Y );
+	
 	CarlaMap = carla::opendrive::OpenDriveParser::Load(opendrive_xml);
 
 	if (!CarlaMap.has_value())
@@ -813,12 +815,12 @@ void UOpenDriveToMap::GenerateCurbSplinesFromRoadRenders()
 		MinPosition = FVector(CurrentTilesInXY.X * TileSize, CurrentTilesInXY.Y * -TileSize, 0.0f);
 		MaxPosition = FVector((CurrentTilesInXY.X + 1.0f) * TileSize, (CurrentTilesInXY.Y + 1.0f) * -TileSize, 0.0f);
 		
-		// RenderRoadToTexture(MinPosition, MaxPosition, "Layer0");
+		RenderRoadToTexture(MinPosition, MaxPosition, "Layer0");
 		RenderRoadToTexture(MinPosition, MaxPosition, "Layer1");
 
 	} while (GoNextTile());
 
-	// GenerateCurbSplines("Layer0");
+	GenerateCurbSplines("Layer0");
 	GenerateCurbSplines("Layer1");
 }
 
@@ -1678,7 +1680,7 @@ void UOpenDriveToMap::RenderRoadToTexture(FVector MinLocation, FVector MaxLocati
 
 	FActorSpawnParameters ActorSpawnParameters;
 	ActorSpawnParameters.SpawnCollisionHandlingOverride = ESpawnActorCollisionHandlingMethod::AlwaysSpawn;
-	ActorSpawnParameters.Name = FName(*(TEXT("Camera") + GetStringForCurrentTile()));
+	ActorSpawnParameters.Name = FName(*(TEXT("Camera_" + MeshLayer) + GetStringForCurrentTile()));
 
 	auto Camera = World->SpawnActor<ASceneCapture2D>(ASceneCapture2D::StaticClass(), ActorSpawnParameters);
 

--- a/Source/CarlaDigitalTwinsTool/Private/Generation/OpenDriveToMap.cpp
+++ b/Source/CarlaDigitalTwinsTool/Private/Generation/OpenDriveToMap.cpp
@@ -813,11 +813,13 @@ void UOpenDriveToMap::GenerateCurbSplinesFromRoadRenders()
 		MinPosition = FVector(CurrentTilesInXY.X * TileSize, CurrentTilesInXY.Y * -TileSize, 0.0f);
 		MaxPosition = FVector((CurrentTilesInXY.X + 1.0f) * TileSize, (CurrentTilesInXY.Y + 1.0f) * -TileSize, 0.0f);
 		
-		RenderRoadToTexture(MinPosition, MaxPosition);
+		// RenderRoadToTexture(MinPosition, MaxPosition, "Layer0");
+		RenderRoadToTexture(MinPosition, MaxPosition, "Layer1");
 
 	} while (GoNextTile());
 
-	GenerateCurbSplines();
+	// GenerateCurbSplines("Layer0");
+	GenerateCurbSplines("Layer1");
 }
 
 TArray<AActor*> UOpenDriveToMap::GenerateMiscActors(float Offset, FVector MinLocation, FVector MaxLocation)
@@ -907,6 +909,7 @@ void UOpenDriveToMap::GenerateRoadMesh(
 		FVector MeshCentroid;
 		carla::road::Lane::LaneType LaneType;
 		int32 Index;
+		FString MeshLayer;
 	};
 
 	TArray<FPreparedMeshData> PreparedMeshes;
@@ -927,14 +930,18 @@ void UOpenDriveToMap::GenerateRoadMesh(
 
 				auto& Vertices = Mesh->GetVertices();
 
+				FString MeshLayer = "Layer0";
+
 				if (LaneType == carla::road::Lane::LaneType::Driving)
 				{
 					for (auto& Vertex : Vertices)
 					{
 						FVector FV = Vertex.ToFVector();
-						Vertex.z +=
-							GetHeight(Vertex.x * 100.0f, Vertex.y * 100.0f, DistanceToLaneBorder(ParamCarlaMap, FV) > 65.0f) /
-							100.0f;
+						if (Vertex.z > 0.0f){
+							MeshLayer = "Layer1";
+						}
+
+						Vertex.z += GetHeight(Vertex.x * 100.0f, Vertex.y * 100.0f, DistanceToLaneBorder(ParamCarlaMap, FV) > 65.0f) / 100.0f;
 					}
 #if ENGINE_MAJOR_VERSION < 5
 					carla::geom::Simplification Simplify(0.15);
@@ -965,6 +972,7 @@ void UOpenDriveToMap::GenerateRoadMesh(
 				Data.MeshData = *Mesh;
 				Data.MeshCentroid = Centroid;
 				Data.LaneType = LaneType;
+				Data.MeshLayer = MeshLayer;
 
 				int32 AssignedIndex;
 				{
@@ -982,6 +990,7 @@ void UOpenDriveToMap::GenerateRoadMesh(
 		const FVector& Centroid = Entry.MeshCentroid;
 		const int32 Index = Entry.Index;
 		const carla::road::Lane::LaneType LaneType = Entry.LaneType;
+		const FString& MeshLayer = Entry.MeshLayer;
 
 		TArray<FProcMeshTangent> Tangents;
 		UKismetProceduralMeshLibrary::CalculateTangentsForMesh(
@@ -1006,7 +1015,7 @@ void UOpenDriveToMap::GenerateRoadMesh(
 
 			StaticMeshComponent->SetMaterial(0, DuplicatedRoadMaterial);
 			StaticMeshComponent->CastShadow = false;
-			TempActor->SetActorLabel(FString("SM_DrivingLane_") + FString::FromInt(Index));
+			TempActor->SetActorLabel(FString("SM_DrivingLane_") + MeshLayer + "_" + FString::FromInt(Index));
 		}
 
 		UStaticMesh* FinalMesh = nullptr;
@@ -1611,7 +1620,7 @@ void UOpenDriveToMap::UnloadWorldPartitionRegion(const FBox& RegionBox)
 	}
 }
 
-void UOpenDriveToMap::RenderRoadToTexture(FVector MinLocation, FVector MaxLocation)
+void UOpenDriveToMap::RenderRoadToTexture(FVector MinLocation, FVector MaxLocation, FString MeshLayer)
 {
 	UE_LOG(LogCarlaDigitalTwinsTool, Log, TEXT("Render road for curbs generation"));
 
@@ -1628,6 +1637,8 @@ void UOpenDriveToMap::RenderRoadToTexture(FVector MinLocation, FVector MaxLocati
 		RoadLabel = "UpdatedRoad";
 	}
 #endif
+
+	RoadLabel += "_" + MeshLayer;
 
 	TArray<AActor*> HiddenActors;
 	{
@@ -1709,7 +1720,7 @@ void UOpenDriveToMap::RenderRoadToTexture(FVector MinLocation, FVector MaxLocati
 	ImageTask->PixelData = MoveTemp(PixelData);
 
 	FString OutPath = UGenerationPathsHelper::GetPythonIntermediatePath(MapName);
-	FString ImagePath = OutPath / TEXT("road_render") + GetStringForCurrentTile() + TEXT(".png");
+	FString ImagePath = OutPath / TEXT("road_render") + "_" + MeshLayer + GetStringForCurrentTile() + TEXT(".png");
 
 	ImageTask->Filename = ImagePath;
 	ImageTask->Format = EImageFormat::PNG;
@@ -1729,7 +1740,7 @@ void UOpenDriveToMap::RenderRoadToTexture(FVector MinLocation, FVector MaxLocati
 	Task.Wait();
 }
 
-void UOpenDriveToMap::GenerateCurbSplines()
+void UOpenDriveToMap::GenerateCurbSplines(FString MeshLayer)
 {
 	UE_LOG(LogCarlaDigitalTwinsTool, Log, TEXT("Create splines for curbs generation"));
 
@@ -1741,7 +1752,7 @@ void UOpenDriveToMap::GenerateCurbSplines()
 
 	RunPythonRoadEdges();
 
-	auto JsonPath = OutPath / TEXT("contours.json");
+	auto JsonPath = OutPath / TEXT("contours_"+MeshLayer+".json");
 
 	MinPosition = FVector(0.0f, 0.0f, 0.0f);
 	MaxPosition = FVector(NumTilesInXY.X * TileSize, NumTilesInXY.Y * -TileSize, 0.0f);

--- a/Source/CarlaDigitalTwinsTool/Public/Generation/OpenDriveToMap.h
+++ b/Source/CarlaDigitalTwinsTool/Public/Generation/OpenDriveToMap.h
@@ -255,7 +255,7 @@ protected:
   void GenerateCurbSplinesFromRoadRenders();
 
   UFUNCTION(BlueprintCallable, Category = "Assets Placement")
-  void AlignSplineToRoadMesh(USplineComponent* Spline, UWorld* World);
+  void AlignSplineToRoadMesh(USplineComponent* Spline, UWorld* World, const FString& NamePrefix);
 
   UFUNCTION(BlueprintCallable, Category = "Mitsuba")
   void ExportStaticMeshToOBJ(UStaticMesh *StaticMesh, const FString &OutputPath);

--- a/Source/CarlaDigitalTwinsTool/Public/Generation/OpenDriveToMap.h
+++ b/Source/CarlaDigitalTwinsTool/Public/Generation/OpenDriveToMap.h
@@ -237,7 +237,7 @@ public:
 protected:
 
   UFUNCTION(BlueprintCallable, Category = "Assets Placement")
-  void RenderRoadToTexture(FVector MinLocation, FVector MaxLocation);
+  void RenderRoadToTexture(FVector MinLocation, FVector MaxLocation, FString MeshLayer);
 
   UFUNCTION(BlueprintCallable, Category = "Assets Placement")
   void RunPythonScript(FString ScriptPath, FString Args);
@@ -249,7 +249,7 @@ protected:
   void RunPythonRoadEdges();
 
   UFUNCTION(BlueprintCallable, Category = "Assets Placement")
-  void GenerateCurbSplines();
+  void GenerateCurbSplines(FString MeshLayer);
 
   UFUNCTION(BlueprintCallable, Category = "Assets Placement")
   void GenerateCurbSplinesFromRoadRenders();

--- a/Source/CarlaDigitalTwinsTool/Public/Generation/OpenDriveToMap.h
+++ b/Source/CarlaDigitalTwinsTool/Public/Generation/OpenDriveToMap.h
@@ -254,6 +254,9 @@ protected:
   UFUNCTION(BlueprintCallable, Category = "Assets Placement")
   void GenerateCurbSplinesFromRoadRenders();
 
+  UFUNCTION(BlueprintCallable, Category = "Assets Placement")
+  void AlignSplineToRoadMesh(USplineComponent* Spline, UWorld* World);
+
   UFUNCTION(BlueprintCallable, Category = "Mitsuba")
   void ExportStaticMeshToOBJ(UStaticMesh *StaticMesh, const FString &OutputPath);
 


### PR DESCRIPTION
In current implementation, curbs are generated from splines spawned with a edge detection algorithm from a bird-eye render of the road. This works fine unless there are different layers of roads: for instance, a bridge over a highway. In that case, the road below the bridge does not have the correspondent curb since is overlapped in the render.

To represent different height roads, in this PR we split roads in two layers: layer 0 as the roads whose points are all on the floor and layer 1 for those which can go higher, such as bridges. The edge detection scripts are thus run for each of the layers, avoiding overlap with roads below bridges.

Moreover, in current implementation, splines are projected to the floor rather than to the exact height of the road, which does not work well for bridges.

In this PR, once the curb spline is generated, it is placed at the correct height using a raycast. This part of the algorithm is done by UOpenDriveToMap::AlignSplineToRoadMesh, but it is not fully working yet, since not all curbs are spawned at the correct height yet but some are.

A possible problem which may arise is the joint between roads of different layers, which may input an inexistent curb there. We need to test if that issue happens and find a way to avoid that.

OSM map used for testing (bridge over highway close to UAB):
https://overpass-api.de/api/map?bbox=2.094655,41.490948,2.096264,41.492812

Linked to [this content PR](https://bitbucket.org/carla-simulator/digitaltwins/pull-requests/31).